### PR TITLE
use ipython: InteractiveShell

### DIFF
--- a/src/ipython_beartype/__init__.py
+++ b/src/ipython_beartype/__init__.py
@@ -2,10 +2,10 @@
 
 from beartype.claw._ast.clawastmain import BeartypeNodeTransformer
 from beartype._conf.confcls import BeartypeConf
-from IPython.terminal.interactiveshell import TerminalInteractiveShell
+from IPython.terminal.interactiveshell import InteractiveShell
 
 
-def load_ipython_extension(ipython: TerminalInteractiveShell) -> None:
+def load_ipython_extension(ipython: InteractiveShell) -> None:
     # The import is local to avoid degrading import times when the magic is
     # not needed.
     from IPython.core.magic import line_magic, Magics, magics_class


### PR DESCRIPTION
Thanks for this elegant little package!

This updates the signature of the `ipython` argument to be the superclass `InteractiveShell`, which makes things work better inside alternate runtimes than an `ipython` CLI, such as `ipykernel`, or the even more exotic [pydodide-kernel](https://github.com/jupyterlite/pyodide-kernel). 

These _work_ today... unless one has already added `beartype` The Hard Way:

```python
%pip install ipython-beartype
import beartype.claw
beartype.claw.beartype_all()
%load_ext ipython_beartype
%beartype
```

```python
BeartypeCallHintParamViolation            Traceback (most recent call last)
...

BeartypeCallHintParamViolation: Function ipython_beartype.load_ipython_extension() parameter ipython=<pyodide_kernel.interpreter.Interpreter object at 0x242e728> violates type hint <class 'IPython.terminal.interactiveshell.TerminalInteractiveShell'>, as <class "pyodide_kernel.interpreter.Interpreter"> <pyodide_kernel.interpreter.Interpreter object at 0x242e728> not instance of <class "IPython.terminal.interactiveshell.TerminalInteractiveShell">.
```

Also, of note: would love to ship this for [`conda-forge`](https://github.com/conda-forge/staged-recipes), but would ideally be able to use one of the following for building from source:
- a source distribution `.tar.gz` on PyPI (preferred by most downstreams)
- a tag here on GitHub

Thanks again :polar_bear: !